### PR TITLE
Abstract the data path

### DIFF
--- a/examples/src/petrol-examples/counter/core.cljs
+++ b/examples/src/petrol-examples/counter/core.cljs
@@ -15,17 +15,18 @@
   []
   (swap! !app identity))
 
-(defn handle! [ui-channel message]
-  (let [focused-message
-        (reify petrol/Message
-          (process-message [this state]
-            (update state :counter (partial petrol/process-message message))))]
-    (petrol/send! ui-channel focused-message)))
+(defn handle-with! [ui-channel fmap]
+  (fn [message]
+    (let [focused-message
+          (reify petrol/Message
+            (process-message [this state]
+              (fmap #(petrol/process-message message %) state)))]
+      (petrol/send! ui-channel focused-message))))
 
 (defn render-fn
   [ui-channel app]
   (reagent/render-component
-    [view/root (partial handle! ui-channel) (:counter app)]
+    [view/root (handle-with! ui-channel #(update %2 :counter %1)) (:counter app)]
     js/document.body))
 
 (defn ^:export main

--- a/examples/src/petrol-examples/counter/core.cljs
+++ b/examples/src/petrol-examples/counter/core.cljs
@@ -15,10 +15,17 @@
   []
   (swap! !app identity))
 
+(defn handle! [ui-channel message]
+  (let [focused-message
+        (reify petrol/Message
+          (process-message [this state]
+            (update state :counter (partial petrol/process-message message))))]
+    (petrol/send! ui-channel focused-message)))
+
 (defn render-fn
   [ui-channel app]
   (reagent/render-component
-    [view/root (partial petrol/send! ui-channel) (:counter app)]
+    [view/root (partial handle! ui-channel) (:counter app)]
     js/document.body))
 
 (defn ^:export main

--- a/examples/src/petrol-examples/counter/core.cljs
+++ b/examples/src/petrol-examples/counter/core.cljs
@@ -17,8 +17,9 @@
 
 (defn render-fn
   [ui-channel app]
-  (reagent/render-component [view/root ui-channel app]
-                            js/document.body))
+  (reagent/render-component
+    [view/root (partial petrol/send! ui-channel) app]
+    js/document.body))
 
 (defn ^:export main
   []

--- a/examples/src/petrol-examples/counter/core.cljs
+++ b/examples/src/petrol-examples/counter/core.cljs
@@ -18,7 +18,7 @@
 (defn render-fn
   [ui-channel app]
   (reagent/render-component
-    [view/root (partial petrol/send! ui-channel) app]
+    [view/root (partial petrol/send! ui-channel) (:counter app)]
     js/document.body))
 
 (defn ^:export main

--- a/examples/src/petrol-examples/counter/processing.cljs
+++ b/examples/src/petrol-examples/counter/processing.cljs
@@ -4,9 +4,9 @@
 
 (extend-protocol Message
   m/Decrement
-  (process-message [_ app]
-    (update app :counter dec))
+  (process-message [_ state]
+    (dec state))
 
   m/Increment
-  (process-message [_ app]
-    (update app :counter inc)))
+  (process-message [_ state]
+    (inc state)))

--- a/examples/src/petrol-examples/counter/view.cljs
+++ b/examples/src/petrol-examples/counter/view.cljs
@@ -2,12 +2,12 @@
   (:require [petrol-examples.counter.messages :as m]))
 
 (defn root
-  [handle! app]
+  [handle! state]
   [:div.container
    [:div.row
     [:div.col-xs-12.col-sm-6.col-lg-4
      [:h1 "Simple Counter"]
-     [:div.well (:counter app)]
+     [:div.well state]
      [:div.btn-group
       [:button.btn.btn-info {:on-click (handle! (m/->Decrement))}
        "Decrement"]

--- a/examples/src/petrol-examples/counter/view.cljs
+++ b/examples/src/petrol-examples/counter/view.cljs
@@ -1,16 +1,15 @@
 (ns petrol-examples.counter.view
-  (:require [petrol.core :refer [send!]]
-            [petrol-examples.counter.messages :as m]))
+  (:require [petrol-examples.counter.messages :as m]))
 
 (defn root
-  [ui-channel app]
+  [handle! app]
   [:div.container
    [:div.row
     [:div.col-xs-12.col-sm-6.col-lg-4
      [:h1 "Simple Counter"]
      [:div.well (:counter app)]
      [:div.btn-group
-      [:button.btn.btn-info {:on-click (send! ui-channel (m/->Decrement))}
+      [:button.btn.btn-info {:on-click (handle! (m/->Decrement))}
        "Decrement"]
-      [:button.btn.btn-info {:on-click (send! ui-channel (m/->Increment))}
+      [:button.btn.btn-info {:on-click (handle! (m/->Increment))}
        "Increment"]]]]])


### PR DESCRIPTION
In the example you presented at ClojureX, knowledge of the core.async channel and the location of the counter's state leaked into the messages and view.

I've refactored this example to remove that coupling. `handle-with!` is a piece of generic machinery that uses an `fmap` function and a `view` function to wire up a component to where to find its state in the overall model. This could easily be pushed into Petrol's core, and possibly replace `send!`.

You could easily write helpers that would construct `fmap` and `view` from a path, though it's not necessary that they use a path at all - you might want to e.g. use a model containing seconds with a component that expects minutes.

This may or may not match your plans for Petrol, but I thought it would be fun to use lens functions to make the wiring up simpler.
