### PR TITLE
Add bidi-routes argument in 2 arity petrol.routing/href-for fn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/.idea
+/petrol.iml
 /target
 /classes
 /checkouts

--- a/src/petrol/routing.cljs
+++ b/src/petrol/routing.cljs
@@ -29,6 +29,6 @@
 
 (defn href-for
   ([bidi-routes handler]
-   (href-for handler {}))
+   (href-for bidi-routes handler {}))
   ([bidi-routes handler args]
    (apply bidi/path-for bidi-routes handler (mapcat identity args))))


### PR DESCRIPTION
The bidi-routes argument was not being passed on to the 3 arity fn.
