### PR TITLE
Reduce over messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ pom.xml.asc
 *.log
 checkouts/
 target/
+/examples/out
+examples/main.js

--- a/src/petrol/core.cljs
+++ b/src/petrol/core.cljs
@@ -85,6 +85,8 @@
 (def ^:private !channels
   (atom #{}))
 
+(def !message-history (atom []))
+
 (defn start-message-loop!
   ([!app render-fn]
    (start-message-loop! !app render-fn #{}))
@@ -103,11 +105,13 @@
 
      (go-loop []
        (when-let [cs (seq @!channels)]
+
          (let [[message channel] (alts! cs)]
            (when (nil? message)
              (swap! !channels disj channel))
 
            (when (satisfies? Message message)
+             (swap! !message-history conj message)
              (swap! !app #(process-message message %)))
 
            (when (satisfies? EventSource message)

--- a/src/petrol/core.cljs
+++ b/src/petrol/core.cljs
@@ -1,6 +1,7 @@
 (ns petrol.core
   (:require [cljs.core.async :as async :refer [alts! put! pipe chan <! >!]]
-            [clojure.set :as set])
+            [clojure.set :as set]
+            [clojure.core.reducers :as r])
   (:require-macros [cljs.core.async.macros :refer [go-loop]]))
 
 (defn wrap
@@ -94,7 +95,8 @@
   ([!app render-fn initial-channels]
    (reset! !channels initial-channels)
 
-   (let [ui-channel (async/chan)]
+   (let [ui-channel (async/chan)
+         initial-state @!app]
      (swap! !channels conj ui-channel)
 
      (add-watch !app :render
@@ -111,8 +113,11 @@
              (swap! !channels disj channel))
 
            (when (satisfies? Message message)
+             ;; add messages to history
              (swap! !message-history conj message)
-             (swap! !app #(process-message message %)))
+
+             ;; reduce over messages and add to state TODO: make more efficient
+             (reset! !app (r/reduce #(process-message %2 %1) initial-state @!message-history)))
 
            (when (satisfies? EventSource message)
              (swap! !channels set/union (watch-channels message @!app))))


### PR DESCRIPTION
This is a WIP PR to address #7. Please review, give it a try and I'd love to have your opinion, but leave it open for now until I fix the open todos.

Messages are now being stored and to produce current state it reduces over these messages. This is great for time travel functionality and reproducibility. Try for example editing the 'processing' of messages and see it change the state. It similar to how Elm and Redux do it.

TODO:
- [x] It currently doesn't have proper caching and thus poor performance when reducing over a lot of messages.
- [x] Better live reload support. Reduce only being done on adding messages and not a figwheel reload.
- [ ] Maybe add some time travel utils (undo, redo)
- [ ] Add demo
